### PR TITLE
lukenamop roles final

### DIFF
--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -436,10 +436,25 @@ class CommentWorker():
             filter(Investor.firm_role == "ceo").\
             first().\
             name
+        coo = concat_names(
+            sess.query(Investor).\
+                filter(Investor.firm == firm.id).\
+                filter(Investor.firm_role == "coo").\
+                all())
+        cfo = concat_names(
+            sess.query(Investor).\
+                filter(Investor.firm == firm.id).\
+                filter(Investor.firm_role == "cfo").\
+                all())
         execs = concat_names(
             sess.query(Investor).\
                 filter(Investor.firm == firm.id).\
                 filter(Investor.firm_role == "exec").\
+                all())
+        assocs = concat_names(
+            sess.query(Investor).\
+                filter(Investor.firm == firm.id).\
+                filter(Investor.firm_role == "assoc").\
                 all())
         traders = concat_names(
             sess.query(Investor).\
@@ -453,8 +468,14 @@ class CommentWorker():
         flair_role = ''
         if investor.firm_role == "ceo":
             flair_role = "CEO"
+        elif investor.firm_role == "coo":
+            flair_role = "COO"
+        elif investor.firm_role == "cfo":
+            flair_role = "CFO"
         elif investor.firm_role == "exec":
             flair_role = "Executive"
+        elif investor.firm_role == "assoc":
+            flair_role = "Associate"
         else:
             flair_role = "Floor Trader"
 
@@ -468,14 +489,20 @@ class CommentWorker():
                     investor.firm_role,
                     firm,
                     ceo,
+                    coo,
+                    cfo,
                     execs,
+                    assocs,
                     traders))
         else:
             return comment.reply_wrap(
                 message.modify_firm_other(
                     firm,
                     ceo,
+                    coo,
+                    cfo,
                     execs,
+                    assocs,
                     traders))
 
     @req_user
@@ -532,13 +559,20 @@ class CommentWorker():
                 count()
             if members > 1:
                 return comment.reply_wrap(message.leavefirm_ceo_failure_org)
+
         firm = sess.query(Firm).\
             filter(Firm.id == investor.firm).\
             first()
 
         firm.size -= 1
-        if investor.firm_role == 'exec':
+        if investor.firm_role == 'coo':
+            firm.coo -= 1
+        elif investor.firm_role == 'cfo':
+            firm.cfo -= 1
+        elif investor.firm_role == 'exec':
             firm.execs -= 1
+        elif investor.firm_role == 'assoc':
+            firm.assocs -= 1
 
         investor.firm = 0
         investor.firm_role = ""
@@ -554,9 +588,6 @@ class CommentWorker():
         if investor.firm == 0:
             return comment.reply_wrap(message.firm_none_org)
 
-        if investor.firm_role != "ceo":
-            return comment.reply_wrap(message.not_ceo_org)
-
         user = sess.query(Investor).\
             filter(func.lower(Investor.name) == func.lower(to_promote)).\
             first()
@@ -568,28 +599,82 @@ class CommentWorker():
             first()
 
         if user.firm_role == "":
+            if (investor.firm_role == "") or (investor.firm_role == "assoc"):
+                return comment.reply_wrap(message.not_ceo_or_exec_org)
+
+            max_assocs = max_assocs_for_rank(firm.rank)
+            if firm.assocs >= max_assocs:
+                return comment.reply_wrap(message.modify_promote_assocs_full(firm))
+
+            user.firm_role = "assoc"
+            firm.assocs += 1
+
+        elif user.firm_role == "assoc":
+            if investor.firm_role != "ceo" and investor.firm_role != "coo":
+                return comment.reply_wrap(message.not_ceo_or_coo_org)
+
             max_execs = max_execs_for_rank(firm.rank)
             if firm.execs >= max_execs:
-                return comment.reply_wrap(message.modify_promote_full(firm))
+                return comment.reply_wrap(message.modify_promote_execs_full(firm))
 
             user.firm_role = "exec"
+            firm.assocs -= 1
             firm.execs += 1
+
         elif user.firm_role == "exec":
+            if investor.firm_role != "ceo":
+                return comment.reply_wrap(message.not_ceo_org)
+
+            if firm.cfo >= 1:
+                return comment.reply_wrap(message.promote_cfo_full_org)
+
+            user.firm_role = "cfo"
+            firm.execs -= 1
+            firm.cfo += 1
+
+        elif user.firm_role == "cfo":
+            if investor.firm_role != "ceo":
+                return comment.reply_wrap(message.not_ceo_org)
+
+            if firm.coo >= 1:
+                return comment.reply_wrap(message.promote_coo_full_org)
+
+            user.firm_role = "coo"
+            firm.cfo -= 1
+            firm.coo += 1
+
+        elif user.firm_role == "coo":
+            if investor.firm_role != "ceo":
+                return comment.reply_wrap(message.not_ceo_org)
+
             # Swapping roles
-            investor.firm_role = "exec"
+            investor.firm_role = "coo"
             user.firm_role = "ceo"
 
         # Updating the flair in subreddits
         flair_role_user = ''
         if user.firm_role == "ceo":
             flair_role_user = "CEO"
-        else:
+        elif user.firm_role == "coo":
+            flair_role_user = "COO"
+        elif user.firm_role == "cfo":
+            flair_role_user = "CFO"
+        elif user.firm_role == "exec":
             flair_role_user = "Executive"
+        elif user.firm_role == "assoc":
+            flair_role_user = "Associate"
+
         flair_role_investor = ''
         if investor.firm_role == "ceo":
             flair_role_investor = "CEO"
-        else:
+        elif investor.firm_role == "coo":
+            flair_role_investor = "COO"
+        elif investor.firm_role == "cfo":
+            flair_role_investor = "CFO"
+        elif investor.firm_role == "exec":
             flair_role_investor = "Executive"
+        elif investor.firm_role == "assoc":
+            flair_role_investor = "Associate"
 
         if not config.TEST:
             for subreddit in config.SUBREDDITS:
@@ -603,26 +688,48 @@ class CommentWorker():
         if investor.firm == 0:
             return comment.reply_wrap(message.firm_none_org)
 
-        if investor.firm_role == "":
-            return comment.reply_wrap(message.not_ceo_or_exec_org)
-
         user = sess.query(Investor).\
             filter(func.lower(Investor.name) == func.lower(to_fire)).\
             first()
         if (user == None) or (user.name == investor.name) or (user.firm != investor.firm):
             return comment.reply_wrap(message.fire_failure_org)
 
-        if (investor.firm_role != "ceo") and (user.firm_role != ""):
-            return comment.reply_wrap(message.not_ceo_org)
+        #if (investor.firm_role != "ceo") and (user.firm_role != ""):
+        #    return comment.reply_wrap(message.not_ceo_org)
 
         firm = sess.query(Firm).\
             filter(Firm.id == investor.firm).\
             first()
 
-        firm.size -= 1
-        if user.firm_role == 'exec':
+        if user.firm_role == "":
+            if (investor.firm_role == "") or (investor.firm_role == "assoc"):
+                return comment.reply_wrap(message.not_ceo_or_exec_org)
+
+        elif user.firm_role == "assoc":
+            if (investor.firm_role == "") or (investor.firm_role == "assoc"):
+                return comment.reply_wrap(message.not_ceo_or_coo_org)
+
+            firm.assocs -= 1
+
+        elif user.firm_role == "exec":
+            if (investor.firm_role != "ceo") and (investor.firm_role != "coo"):
+                return comment.reply_wrap(message.not_ceo_or_coo_org)
+
             firm.execs -= 1
 
+        elif user.firm_role == "cfo":
+            if (investor.firm_role != "ceo"):
+                return comment.reply_wrap(message.not_ceo_org)
+
+            firm.cfo -= 1
+
+        elif user.firm_role == "coo":
+            if (investor.firm_role != "ceo"):
+                return comment.reply_wrap(message.not_ceo_org)
+
+            firm.coo -= 1
+
+        firm.size -= 1
         user.firm_role = ""
         user.firm = 0
 
@@ -630,6 +737,7 @@ class CommentWorker():
         if not config.TEST:
             for subreddit in config.SUBREDDITS:
                 REDDIT.subreddit(subreddit).flair.set(user.name, '')
+
         return comment.reply_wrap(message.modify_fire(user))
 
     @req_user
@@ -672,7 +780,7 @@ class CommentWorker():
             return comment.reply_wrap(message.no_firm_failure_org)
 
         if investor.firm_role == "":
-            return comment.reply_wrap(message.not_ceo_or_exec_org)
+            return comment.reply_wrap(message.not_assoc_org)
 
         firm = sess.query(Firm).\
             filter(Firm.id == investor.firm).\
@@ -698,8 +806,8 @@ class CommentWorker():
         if investor.firm == 0:
             return comment.reply_wrap(message.no_firm_failure_org)
 
-        if investor.firm_role != "ceo":
-            return comment.reply_wrap(message.not_ceo_org)
+        if investor.firm_role != "ceo" and investor.firm_role != "coo":
+            return comment.reply_wrap(message.not_ceo_or_coo_org)
 
         firm = sess.query(Firm).\
             filter(Firm.id == investor.firm).\
@@ -714,8 +822,8 @@ class CommentWorker():
         if investor.firm == 0:
             return comment.reply_wrap(message.no_firm_failure_org)
 
-        if investor.firm_role != "ceo":
-            return comment.reply_wrap(message.not_ceo_org)
+        if (investor.firm_role != "ceo") and (investor.firm_role != "coo"):
+            return comment.reply_wrap(message.not_ceo_or_coo_org)
 
         firm = sess.query(Firm).\
             filter(Firm.id == investor.firm).\
@@ -723,16 +831,15 @@ class CommentWorker():
 
         firm.private = False
 
-        return comment.reply_wrap(message.setprivate_org)
+        return comment.reply_wrap(message.setpublic_org)
 
     @req_user
     def tax(self, sess, comment, investor, tax_temp):
-
         if investor.firm == 0:
             return comment.reply_wrap(message.no_firm_failure_org)
 
-        if investor.firm_role != "ceo":
-            return comment.reply_wrap(message.not_ceo_org)
+        if (investor.firm_role != "ceo") and (investor.firm_role != "cfo"):
+            return comment.reply_wrap(message.not_ceo_or_cfo_org)
 
         firm = sess.query(Firm).\
             filter(Firm.id == investor.firm).\
@@ -759,8 +866,8 @@ class CommentWorker():
         if investor.firm == 0:
             return comment.reply_wrap(message.nofirm_failure_org)
 
-        if investor.firm_role != "ceo":
-            return comment.reply_wrap(message.not_ceo_org)
+        if (investor.firm_role != "ceo") and (investor.firm_role != "cfo"):
+            return comment.reply_wrap(message.not_ceo_or_cfo_org)
 
         firm = sess.query(Firm).\
             filter(Firm.id == investor.firm).\
@@ -779,8 +886,9 @@ class CommentWorker():
 
         max_members = max_members_for_rank(firm.rank)
         max_execs = max_execs_for_rank(firm.rank)
+        max_assocs = max_assocs_for_rank(firm.rank)
 
-        return comment.reply_wrap(message.modify_upgrade(firm, max_members, max_execs))
+        return comment.reply_wrap(message.modify_upgrade(firm, max_members, max_execs, max_assocs))
 
 def concat_names(investors):
     names = ["/u/" + i.name for i in investors]
@@ -791,11 +899,18 @@ def max_members_for_rank(rank):
     # level 2 = 16
     # level 3 = 32
     # etc.
-    return 2 ** (rank + 3)
+    return int(2 ** (rank + 3))
+
+def max_assocs_for_rank(rank):
+    # level 1 = 2
+    # level 2 = 6
+    # level 3 = 14
+    # etc.
+    return int(((2 ** (rank + 3)) / 2) - 2)
 
 def max_execs_for_rank(rank):
     # level 1 = 2
     # level 2 = 4
     # level 3 = 8
     # etc.
-    return 2 ** (rank + 1)
+    return int(2 ** (rank + 1))

--- a/src/message.py
+++ b/src/message.py
@@ -386,12 +386,33 @@ Firm level: **%LEVEL%**
 *CEO:*
 %CEO%
 
+*COO:*
+%COO%
+
+*CFO:*
+%CFO%
+
 *Executives:*
 %EXECS%
+
+*Associates:*
+%ASSOCS%
 
 *Floor Traders:*
 %TRADERS%
 """
+
+def modify_firm_other(firm, ceo, coo, cfo, execs, assocs, traders):
+    return firm_other_org.\
+        replace("%FIRM_NAME%", firm.name).\
+        replace("%CEO%", ceo).\
+        replace("%COO%", coo).\
+        replace("%CFO%", cfo).\
+        replace("%EXECS%", execs).\
+        replace("%ASSOCS%", assocs).\
+        replace("%TRADERS%", traders).\
+        replace("%BALANCE%", "{:,}".format(firm.balance)).\
+        replace("%LEVEL%", str(firm.rank + 1))
 
 firm_self_org = """
 Firm: **%FIRM_NAME%**
@@ -409,8 +430,17 @@ Your Rank: **%RANK%**
 *CEO:*
 %CEO%
 
+*COO:*
+%COO%
+
+*CFO:*
+%CFO%
+
 *Executives:*
 %EXECS%
+
+*Associates:*
+%ASSOCS%
 
 *Floor Traders:*
 %TRADERS%
@@ -420,35 +450,32 @@ Your Rank: **%RANK%**
 You can leave this firm with the **!leavefirm** command.
 """
 
+def modify_firm_self(rank, firm, ceo, coo, cfo, execs, assocs, traders):
+    rank_str = rank_strs[rank]
+    return firm_self_org.\
+        replace("%RANK%", rank_str).\
+        replace("%FIRM_NAME%", firm.name).\
+        replace("%CEO%", ceo).\
+        replace("%COO%", coo).\
+        replace("%CFO%", cfo).\
+        replace("%EXECS%", execs).\
+        replace("%ASSOCS%", assocs).\
+        replace("%TRADERS%", traders).\
+        replace("%BALANCE%", "{:,}".format(firm.balance)).\
+        replace("%LEVEL%", str(firm.rank + 1))
+
 firm_notfound_org = """
 No firm was found with this name.
 """
 
 rank_strs = {
     "ceo": "CEO",
+    "coo": "COO",
+    "cfo": "CFO",
     "exec": "Executive",
+    "assoc": "Associate",
     "": "Floor Trader"
 }
-
-def modify_firm_other(firm, ceo, execs, traders):
-    return firm_other_org.\
-        replace("%FIRM_NAME%", firm.name).\
-        replace("%CEO%", ceo).\
-        replace("%EXECS%", execs).\
-        replace("%TRADERS%", traders).\
-        replace("%BALANCE%", "{:,}".format(firm.balance)).\
-        replace("%LEVEL%", str(firm.rank + 1))
-
-def modify_firm_self(rank, firm, ceo, execs, traders):
-    rank_str = rank_strs[rank]
-    return firm_self_org.\
-        replace("%RANK%", rank_str).\
-        replace("%FIRM_NAME%", firm.name).\
-        replace("%CEO%", ceo).\
-        replace("%EXECS%", execs).\
-        replace("%TRADERS%", traders).\
-        replace("%BALANCE%", "{:,}".format(firm.balance)).\
-        replace("%LEVEL%", str(firm.rank + 1))
 
 createfirm_exists_failure_org = """
 You are already in a firm: **%FIRM_NAME%**
@@ -486,7 +513,7 @@ no_firm_failure_org = leavefirm_none_failure_org
 leavefirm_ceo_failure_org = """
 You are currently the CEO of your firm, so you are not allowed to leave.
 
-If you really want to leave, you will need to first demote yourself by promoting an executive member to CEO with the **!promote <username>** command.
+If you really want to leave, you will need to first demote yourself by promoting a COO or CFO member to CEO with the **!promote <username>** command.
 """
 
 leavefirm_org = """
@@ -497,26 +524,63 @@ not_ceo_org = """
 Only the CEO can do that.
 """
 
+not_ceo_or_coo_org = """
+Only the CEO or COO can do that.
+"""
+
+not_ceo_or_cfo_org = """
+Only the CEO or CFO can do that.
+"""
+
 not_ceo_or_exec_org = """
-Only the CEO and executives can do that.
+Only a member of the board or an executive can do that.
+"""
+
+not_assoc_org = """
+Floor Traders cannot send invites.
 """
 
 promote_failure_org = """
 Couldn't promote user, make sure you used the correct username.
 """
 
-promote_full_org = """
-Could not promote this employee, since the firm is at its maximum executive limit.
-**Number of execs:** %EXECS%
-**Firm level:** %LEVEL%
-
-The CEO of the firm can raise this limit by upgrading with `!upgrade`.
+promote_coo_full_org = """
+Could not promote this employee since the firm already has a COO.
 """
 
-def modify_promote_full(firm):
-    return promote_full_org.\
+promote_cfo_full_org = """
+Could not promote this employee since the firm already has a CFO.
+"""
+
+promote_execs_full_org = """
+Could not promote this employee since the firm is at its maximum executive limit.
+**Number of executives:** %EXECS%
+**Firm level:** %LEVEL%
+
+The CEO or CFO of the firm can raise this limit by upgrading with `!upgrade`.
+"""
+
+def modify_promote_execs_full(firm):
+    return promote_execs_full_org.\
         replace("%EXECS%", str(firm.execs)).\
         replace("%LEVEL%", str(firm.rank + 1))
+
+promote_assocs_full_org = """
+Could not promote this employee since the firm is at its maximum associate limit.
+**Number of associates:** %ASSOCS%
+**Firm level:** %LEVEL%
+
+The CEO or CFO of the firm can raise this limit by upgrading with `!upgrade`.
+"""
+
+def modify_promote_assocs_full(firm):
+    return promote_assocs_full_org.\
+        replace("%ASSOCS%", str(firm.assocs)).\
+        replace("%LEVEL%", str(firm.rank + 1))
+
+promote_org = """
+Successfully promoted **/u/%NAME%** to **%RANK%**.
+"""
 
 def modify_promote(user):
     rank_str = rank_strs[user.firm_role]
@@ -524,17 +588,13 @@ def modify_promote(user):
         replace("%NAME%", user.name).\
         replace("%RANK%", rank_str)
 
-promote_org = """
-Successfully promoted **/u/%NAME%** to **%RANK%**.
+fire_org = """
+Successfully fired **/u/%NAME%** from the firm.
 """
 
 def modify_fire(user):
     return fire_org.\
         replace("%NAME%", user.name)
-
-fire_org = """
-Successfully fired **/u/%NAME%** from the firm.
-"""
 
 fire_failure_org = """
 Couldn't fire user, make sure you used the correct username.
@@ -547,7 +607,7 @@ Can't join a firm because you are already in one. Use the *!leavefirm* command t
 joinfirm_private_failure_org = """
 Can't join this firm because it is set to private and you have not been invited.
 
-The CEO or Executives must first invite you with the `!invite <username>` command.
+A member of the firm must first invite you with the `!invite <username>` command.
 """
 
 joinfirm_failure_org = """
@@ -559,7 +619,7 @@ Could not join the firm, since it is at its maximum member limit.
 **Number of employees:** %MEMBERS%
 **Firm level:** %LEVEL%
 
-The CEO of the firm can raise this limit by upgrading with `!upgrade`.
+The CEO or CFO of the firm can raise this limit by upgrading with `!upgrade`.
 """
 
 def modify_joinfirm_full(firm):
@@ -614,7 +674,7 @@ You don't need to invite anyone since your firm is not private.
 
 That investor can join with the `!joinfirm <firm_name>` command.
 
-If you're the CEO and you would like the firm to be invite-only, use the `!setprivate` command.
+If you're the CEO or COO and you would like the firm to be invite-only, use the `!setprivate` command.
 """
 
 invite_no_user_failure_org = """
@@ -637,7 +697,7 @@ def modify_invite(invitee, firm):
         replace("%FIRM%", firm.name)
 
 setprivate_org = """
-The firm is now private. Users can only join after you or an Executive sends an invite with the `!invite <user>` command.
+The firm is now private. Users can only join after a member of the firm sends an invite with the `!invite <user>` command.
 
 If you'd like to reverse this, use the `!setpublic` command.
 """
@@ -663,14 +723,15 @@ def modify_upgrade_insufficient_funds_org(firm, cost):
 upgrade_org = """
 You have succesfully upgraded the firm to **level %LEVEL%**!
 
-The firm may now have up to **%MAX_MEMBERS% employees**, including up to **%MAX_EXECS% executives**.
+The firm may now have up to **%MAX_MEMBERS% employees**, including up to **%MAX_EXECS% executives** and **%MAX_ASSOCS% associates**.
 """
 
-def modify_upgrade(firm, max_members, max_execs):
+def modify_upgrade(firm, max_members, max_execs, max_assocs):
     return upgrade_org.\
         replace("%LEVEL%", str(firm.rank + 1)).\
         replace("%MAX_MEMBERS%", str(max_members)).\
-        replace("%MAX_EXECS%", str(max_execs))
+        replace("%MAX_EXECS%", str(max_execs)).\
+        replace("%MAX_ASSOCS%", str(max_assocs))
 DEPLOY_VERSION = """
 Current version of the bot is deployed since `%DATE%`
 """

--- a/src/models.py
+++ b/src/models.py
@@ -18,11 +18,11 @@ class unix_timestamp(expression.FunctionElement):
 
 @compiles(unix_timestamp)
 def compile(element, compiler, **kw):
-	if config.TEST:
-		# sqlite (used in tests)
-		return "(strftime('%s', 'now'))"
-	# mariadb
-	return "unix_timestamp()"
+    if config.TEST:
+        # sqlite (used in tests)
+        return "(strftime('%s', 'now'))"
+    # mariadb
+    return "unix_timestamp()"
 
 
 Base = declarative_base()
@@ -71,7 +71,10 @@ class Firm(Base):
     name = Column(String(32), nullable=False, unique=True)
     balance = Column(BigInteger, default=1000)
     size = Column(Integer, default=0)
+    coo = Column(Integer, default=0)
+    cfo = Column(Integer, default=0)
     execs = Column(Integer, default=0)
+    assocs = Column(Integer, default=0)
     tax = Column(Integer, default=15)
     rank = Column(Integer, default=0)
     private = Column(Boolean, default=False)


### PR DESCRIPTION
Fully tested:
![Screen Shot 2019-03-09 at 01 06 59](https://user-images.githubusercontent.com/27683594/54067675-53866900-4208-11e9-9e00-34291c532c96.png)


Added roles "Associate", "CFO" (Chief Financial Officer), and "COO" (Chief Operating Officer). Updated comment_worker.py, message.py, and models.py to reflect the added roles.

Also updated payroll.py with the added roles. (Might go through and re-optimize payroll.py to better take account for empty roles.)

Ideally, with more roles, the CEO could type something like "!promote lukenamop CFO", but I don't have enough experience in python to figure that out so for now it's just iterative in this order:

Floor Trader:
- no permissions

Associate:
- invite other users to the firm

Executive:
- invite
- promote/demote users to/from associate

CFO (max 1):
- invite
- promote/demote users to/from associate
- change tax rate
- upgrade firm

COO (max 1):
- invite
- promote/demote users to/from executive
- setprivate/setpublic

CEO:
- all permissions